### PR TITLE
Install munin package before creating munin-conf.d directory.

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -30,6 +30,7 @@ class munin::master ($node_definitions={}) {
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
+    require => Package['munin'],
   }
 
   # Collect all exported node definitions


### PR DESCRIPTION
Hi Stig, 

great Puppet module which saves me a lot of time  :-). Please merge this small patch to avoid an error message due to the missing parent directory /etc/munin on a fresh install.

Best wishes,
Matthias
