### PR TITLE
Changes for using the plugin in RHEL / CentOS

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -6,8 +6,6 @@
 # - allow: List of IPv4 and IPv6 addresses and networks to allow to
 #   connect.
 #
-include munin::params
-
 class munin::node (
   $allow=['127.0.0.1'],
   $nodeconfig=[],
@@ -17,9 +15,9 @@ class munin::node (
   $address=$::fqdn,
   $config_root='/etc/munin',
   $service_name='munin-node',
-  $log_file = $munin::params::log_file,
 )
 {
+  include munin::params
 
   validate_array($allow)
   validate_array($nodeconfig)
@@ -29,6 +27,7 @@ class munin::node (
   validate_string($address)
   validate_absolute_path($config_root)
   validate_string($service_name)
+  $log_dir = $munin::params::log_dir
 
   if $mastergroup {
     $fqn = "${mastergroup};${::fqdn}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,13 +3,13 @@
 class munin::params {
   case $::osfamily {
     RedHat: {
-      $log_file = '/var/log/munin-node/munin-node.log'
+      $log_dir = '/var/log/munin-node'
     }
     Debian: {
-      $log_file = '/var/log/munin/munin-node.log'
+      $log_dir = '/var/log/munin'
     }
     default: {
-      fail("Unsupported osfamily: ${::osfamily} The munin:params module only supports osfamily Debian or RedHat (slaves only).")
+      fail("Unsupported osfamily: ${::osfamily} The munin::params module only supports osfamily Debian or RedHat (slaves only).")
     }
   }
 }

--- a/templates/munin-node.conf.erb
+++ b/templates/munin-node.conf.erb
@@ -5,7 +5,7 @@
 
 host_name  <%= fqdn %>
 log_level  4
-log_file   <%= log_file %>
+log_dir    <%= log_dir %>/munin-node.log
 port       4949
 pid_file   /var/run/munin/munin-node.pid
 background 1


### PR DESCRIPTION
I modified the code to use both Debian + RedHat systems with the plugin. The difference is in munin node log path - where Debian is using /var/log/munin and RedHat is using /var/log/munin-node. If I use the current plugin in CentOS, it will not start, because log_file in munin-node.conf.erb pointing to the /var/log/munin/... which doesn't exist in CentOS.
