### PR TITLE
add FreeBSD and DragonFly support for munin-node

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -28,6 +28,9 @@
 #
 # export_node: "enabled" or "disabled". Defaults to "enabled".
 # Causes the node config to be exported to puppetmaster.
+#
+# file_group: The UNIX group name owning the configuration files,
+# log files, etc.
 
 class munin::node (
   $address        = $munin::params::node::address,
@@ -43,6 +46,7 @@ class munin::node (
   $service_ensure = $munin::params::node::service_ensure,
   $service_name   = $munin::params::node::service_name,
   $export_node    = $munin::params::node::export_node,
+  $file_group     = $munin::params::node::file_group,
 ) inherits munin::params::node {
 
   validate_array($allow)
@@ -58,6 +62,7 @@ class munin::node (
   validate_re($service_ensure, '^(|running|stopped)$')
   validate_re($export_node, '^(enabled|disabled)$')
   validate_absolute_path($log_dir)
+  validate_string($file_group)
 
   if $mastergroup {
     $fqn = "${mastergroup};${::fqdn}"
@@ -70,7 +75,7 @@ class munin::node (
   File {
     ensure => present,
     owner  => 'root',
-    group  => 'root',
+    group  => $file_group,
     mode   => '0444',
   }
 

--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -19,6 +19,7 @@ class munin::params::node {
       $service_name = 'munin-node'
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/share/munin/plugins'
+      $file_group   = 'root'
     }
     Debian: {
       $config_root  = '/etc/munin'
@@ -26,6 +27,7 @@ class munin::params::node {
       $service_name = 'munin-node'
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/share/munin/plugins'
+      $file_group   = 'root'
     }
     Solaris: {
       case $::operatingsystem {
@@ -35,11 +37,20 @@ class munin::params::node {
           $service_name = 'smf:/munin-node'
           $package_name = 'munin-node'
           $plugin_share_dir = '/opt/local/share/munin/plugins'
+          $file_group   = 'root'
         }
         default: {
           fail("Unsupported operatingsystem ${::operatingsystem} for osfamily ${::osfamily}")
         }
       }
+    }
+    FreeBSD, DragonFly: {
+      $config_root  = '/usr/local/etc/munin'
+      $log_dir      = '/var/log/munin'
+      $service_name = 'munin-node'
+      $package_name = 'munin-node'
+      $plugin_share_dir = '/usr/local/share/munin/plugins'
+      $file_group   = 'wheel'
     }
     default: {
       fail($message)

--- a/metadata.json
+++ b/metadata.json
@@ -55,6 +55,12 @@
     },
     {
       "operatingsystem": "Ubuntu"
+    },
+    {
+      "operatingsystem": "FreeBSD"
+    },
+    {
+      "operatingsystem": "DragonFly"
     }
   ]
 }

--- a/templates/munin-node.conf.erb
+++ b/templates/munin-node.conf.erb
@@ -14,7 +14,7 @@ setsid     1
 # Which port to bind to;
 
 user  root
-group root
+group <%= @file_group %>
 
 # Regexps for files to ignore
 


### PR DESCRIPTION
This commit adds support for munin-node on DragonFly and FreeBSD. I'm hoping this can be merged back into your tree!

Thanks,
Alex
