### PR TITLE
Allow absolute targets for plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -43,6 +43,9 @@ define munin::plugin (
                 '': {
                     $plugin_target = "${munin::node::plugin_share_dir}/${title}"
                 }
+                /^\//: {
+                    $plugin_target = $target
+                }
                 default: {
                     $plugin_target = "${munin::node::plugin_share_dir}/${target}"
                 }


### PR DESCRIPTION
This is a proposed patch to allow munin plugins symlinks to point to an absolute filesystem target - I found this necessary for using munin-rails-plugins, where the munin plugins are actually in a gem directory, for example.
