### PR TITLE
Extra regexes in munin-node template to support IPv6 and a default allow

### DIFF
--- a/templates/munin-node.conf.erb
+++ b/templates/munin-node.conf.erb
@@ -32,9 +32,8 @@ ignore_file \.puppet-bak$
 <%=    line.gsub(".", "\\.").sub(/^/, "allow ^").sub(/$/, "$") %>
 <%   elsif line.match(/^\d+\.\d+\.\d+\.\d+\/\d+$/)            -%>
 <%=    line.sub(/^/, "cidr_allow ")                            %>
-<%   elsif line.match(/(\d+|:{1,2})\/\d+$/)                   -%>
+<%   elsif line.match(/([0-9a-fA-F]{1,4}|:{1,2})\/\d+$/)      -%>
 <%=    line.sub(/^/, "cidr_allow ")                            %>
-<%   elsif line.match(/(\d+|:{1,2})\/\d+$/)                   -%>
 <%   else                                                     -%>
 <%=    line.sub(/^/, "allow ^").sub(/$/, "$")                  %>
 <%   end                                                      -%>


### PR DESCRIPTION
This patch allows IPv6 (which won't pass the regex, currently) addresses expplicitly with allow_cidr rules, and provides a more general failsafe for "allow" rules if nothing matches.  This would put the burden on the caller to supply syntactically correct network blocks.
