### PR TITLE
Allow IPv6 addresses in munin-node.conf allow/cidr_allow

### DIFF
--- a/templates/munin-node.conf.erb
+++ b/templates/munin-node.conf.erb
@@ -32,6 +32,10 @@ ignore_file \.puppet-bak$
 <%=    line.gsub(".", "\\.").sub(/^/, "allow ^").sub(/$/, "$") %>
 <%   elsif line.match(/^\d+\.\d+\.\d+\.\d+\/\d+$/)            -%>
 <%=    line.sub(/^/, "cidr_allow ")                            %>
+<%   elsif line.match(/^[0-9a-f:]+$/i)                        -%>
+<%=    line.sub(/^/, "allow ^").sub(/$/, "$")                  %>
+<%   elsif line.match(/^[0-9a-f:]+\/\d+$/i)                   -%>
+<%=    line.sub(/^/, "cidr_allow ")                            %>
 <%   end                                                      -%>
 <% end                                                        -%>
 


### PR DESCRIPTION
It is currently not possible to allow IPv6 addresses as master in `munin-node.conf`. This expands the regular expression matching to allow IPv6.
