### PR TITLE
Fix plufin_conf label

### DIFF
--- a/templates/plugin_conf.erb
+++ b/templates/plugin_conf.erb
@@ -1,6 +1,6 @@
 <%
 # Select label from either config_label or from the namevar
-if @config_label == :undef then
+if @config_label == :undef or @config_label.nil? then
     label = @name
 else
     label = @config_label


### PR DESCRIPTION
In recent puppet version, @config_label can also be nil instead of
:undef, in puppet templates.
