### PR TITLE
Restore empty $mastergroup behaviour in Puppet >= 4.0

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -77,7 +77,7 @@ class munin::node (
   validate_absolute_path($log_dir)
   validate_string($file_group)
 
-  if $mastergroup {
+  if $mastergroup and $mastergroup != ''{
     $fqn = "${mastergroup};${host_name}"
   }
   else {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -40,6 +40,9 @@ define munin::plugin (
             $handle_plugin = true
             $plugin_ensure = link
             case $target {
+                undef: {
+                    $plugin_target = "${munin::node::plugin_share_dir}/${title}"
+                }
                 '': {
                     $plugin_target = "${munin::node::plugin_share_dir}/${title}"
                 }


### PR DESCRIPTION
The new Puppet language parser/evaluator in 4.0 doesn't treat an empty
string `''` the same as an undefined string. This breaks the
`$mastergroup` variable and node definition files by leading to FQNs
such as `$fqn = ";host.example.com"`.

Explicitly checking for an empty string restores the intended behaviour.