### PR TITLE
Move export/collect to separate classes

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -121,22 +121,10 @@ class munin::master (
     force   => true,
   }
 
-  case $collect_nodes {
-    'enabled': {
-      Munin::Master::Node_definition <<| |>>
-    }
-    'mine': {
-      # Collect nodes explicitly tagged with this master
-      Munin::Master::Node_definition <<| tag == "munin::master::${host_name}" |>>
-    }
-    'unclaimed': {
-      # Collect all exported node definitions, except the ones tagged
-      # for a specific master
-      Munin::Master::Node_definition <<| tag == 'munin::master::' |>>
-    }
-    'disabled',
-    default: {
-      # do nothing
+  if $collect_nodes != 'disabled' {
+    class { 'munin::master::collect':
+      collect_nodes => $collect_nodes,
+      host_name     => $host_name,
     }
   }
 

--- a/manifests/master/collect.pp
+++ b/manifests/master/collect.pp
@@ -1,0 +1,30 @@
+# Class to collect the exported munin nodes.
+#
+# This is separated into its own class to avoid warnings about missing
+# storeconfigs.
+#
+
+class munin::master::collect (
+  $collect_nodes,
+  $host_name,
+)
+{
+  case $collect_nodes {
+    'enabled': {
+      Munin::Master::Node_definition <<| |>>
+    }
+    'mine': {
+      # Collect nodes explicitly tagged with this master
+      Munin::Master::Node_definition <<| tag == "munin::master::${host_name}" |>>
+    }
+    'unclaimed': {
+      # Collect all exported node definitions, except the ones tagged
+      # for a specific master
+      Munin::Master::Node_definition <<| tag == 'munin::master::' |>>
+    }
+    'disabled',
+    default: {
+      # do nothing
+    }
+  }
+}

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -155,13 +155,15 @@ class munin::node (
     notify  => Service[$service_name],
   }
 
-  # Export a node definition to be collected by the munin master
+  # Export a node definition to be collected by the munin master.
+  # (Separated into its own class to prevent warnings about "missing
+  # storeconfigs", even if $export_node is not enabled)
   if $export_node == 'enabled' {
-    @@munin::master::node_definition{ $fqn:
-      address    => $address,
-      mastername => $mastername,
-      config     => $masterconfig,
-      tag        => [ "munin::master::${mastername}" ]
+    class { 'munin::node::export':
+      address      => $address,
+      fqn          => $fqn,
+      mastername   => $mastername,
+      masterconfig => $masterconfig,
     }
   }
 

--- a/manifests/node/export.pp
+++ b/manifests/node/export.pp
@@ -1,0 +1,19 @@
+# Class to export the munin node.
+#
+# This is separated into its own class to avoid warnings about missing
+# storeconfigs.
+#
+class munin::node::export (
+  $address,
+  $fqn,
+  $masterconfig,
+  $mastername,
+)
+{
+  @@munin::master::node_definition{ $fqn:
+    address    => $address,
+    mastername => $mastername,
+    config     => $masterconfig,
+    tag        => [ "munin::master::${mastername}" ],
+  }
+}


### PR DESCRIPTION
This will avoid logging warnings when compiling the catalog with
storeconfigs disabled, for instance when using "puppet apply".

This closes #30