### PR TITLE
Add missing dependency on munin-node package

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -176,6 +176,7 @@ class munin::node (
       ensure  => directory,
       recurse => true,
       purge   => true,
+      require => Package[$package_name],
       notify  => Service[$service_name],
     }
   }


### PR DESCRIPTION
When provisioning an instance from scratch, Puppet likes to reshuffle the resources and executes the `file` resource before installing the `munin-node` package. This causes the Puppet run to fail because the parent directory `/etc/munin` is not existing, yet.

This change adds the missing dependency on the package so the unmanaged plugins and configurations are purged _after_ the installation of the package.