### PR TITLE
Rescue InvalidAddressError only if supported

### DIFF
--- a/templates/munin-node.conf.erb
+++ b/templates/munin-node.conf.erb
@@ -8,13 +8,19 @@
   addresses = []
   unrecognized = []
 
+  rescuable_exceptions = [ ArgumentError ]
+
+  if defined?(IPAddr::InvalidAddressError)
+    rescuable_exceptions << IPAddr::InvalidAddressError
+  end
+
   Array(@allow).flatten.each do |line|
     begin
       a = IPAddr.new(line)
       if a.ipv4? or a.ipv6?
         addresses << line
       end
-    rescue ArgumentError, IPAddr::InvalidAddressError
+    rescue *rescuable_exceptions
       # Treat invalid addresses as "allow" arguments, as they can be
       # regular expressions.
       unrecognized << line


### PR DESCRIPTION
Fix for following issue on PE 3.8

    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template     munin/munin-node.conf.erb:
      Filepath: org/jruby/RubyModule.java
      Line: 2726
      Detail: uninitialized constant IPAddr::InvalidAddressError
     at /etc/puppetlabs/puppet/environments/production/modules/munin/manifests/node.pp:153 on node     wind.vlan21
    Warning: Not using cache on failed catalog
    Error: Could not retrieve catalog; skipping run
