### PR TITLE
Standardize module name to ssm-munin

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "ssm/munin",
+  "name": "ssm-munin",
   "version": "0.0.10",
   "author": "ssm",
   "license": "Apache-2.0",


### PR DESCRIPTION
Puppet modules should be named user-modulename and not
user/modulename, according to official Puppetlabs guidelines:
https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#a-note-on-module-names