### PR TITLE
a convenient way for a node to export additional node_definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Parameters for the munin node service and configuration
 * **nodeconfig**: Array of extra configuration lines to append to the
   munin node configuration. (optional, no default)
 
+### Export extra nodes ###
+
+If **munin::node::export_node** is enabled, you may export additional
+nodes with the **munin::node::export::node_definitions** hash.  These
+are exported as **munin::master::node_definition** resources.  They will
+be associated with the same mastername as the node itself.
 
 ## munin::master ##
 
@@ -300,8 +306,8 @@ plugin configuration can be managed with the **config** and
 The munin master class will collect all
 "munin::master::node_definition" exported by "munin::node".
 
-For extra nodes, you can define them in hiera, and munin::master will
-create them.  Example:
+For extra nodes, you can define them in hiera data for the master
+server, and munin::master will create them.  Example:
 
     munin::master::node_definition { 'foo.example.com':
       address => '192.0.2.1'
@@ -313,6 +319,8 @@ create them.  Example:
                    'load.load.predict 86400,12' ],
     }
 
+See also **munin::node::export::node_definitions** for extra nodes
+declared on the clients.
 
 ### node definitions as class parameter ###
 

--- a/manifests/node/export.pp
+++ b/manifests/node/export.pp
@@ -8,12 +8,18 @@ class munin::node::export (
   $fqn,
   $masterconfig,
   $mastername,
+  $node_definitions = {},
 )
 {
+  Munin::Master::Node_definition {
+    mastername => $mastername,
+    tag        => "munin::master::${mastername}",
+  }
   @@munin::master::node_definition{ $fqn:
     address    => $address,
-    mastername => $mastername,
     config     => $masterconfig,
-    tag        => [ "munin::master::${mastername}" ],
+  }
+  if ! empty($node_definitions) {
+    create_resources('@@munin::master::node_definition', $node_definitions)
   }
 }

--- a/spec/classes/munin_node_export_spec.rb
+++ b/spec/classes/munin_node_export_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+_params = {
+  :address => '127.0.0.2',
+  :fqn => 'example;foo.example.com',
+  :masterconfig => [],
+  :mastername => 'munin.example.com'
+}
+_extra_nodes = {
+  'example;svc10.example.com' => {
+    'address' => '127.0.0.10',
+    'config'  => [],
+  },
+  'example;svc11.example.com' => {
+    'address' => '127.0.0.11',
+    'config'  => ['env foo.warn 12'],
+  }
+}
+
+describe 'munin::node::export' do
+
+  on_supported_os.each do |os, facts|
+
+    context "on #{os}" do
+      let(:facts) do facts end
+      let(:params) do _params end
+
+      it do
+        should compile.with_all_deps
+      end
+
+      it do
+        expect(exported_resources).to have_munin__master__node_definition_resource_count(1)
+      end
+      it do
+        expect(exported_resources).to contain_munin__master__node_definition(_params[:fqn])
+                                        .with_address(_params[:address])
+                                        .with_mastername(_params[:mastername])
+                                        .with_tag(["munin::master::#{_params[:mastername]}"])
+      end
+    end
+
+    context "on #{os} with extra nodes" do
+      let(:facts) do facts end
+      let(:params) do _params.merge({ :node_definitions => _extra_nodes }) end
+
+      it { should compile.with_all_deps }
+
+      it do
+        expect(exported_resources).to have_munin__master__node_definition_resource_count(3)
+      end
+      it do
+        expect(exported_resources).to contain_munin__master__node_definition(_params[:fqn])
+                                        .with_address(_params[:address])
+                                        .with_mastername(_params[:mastername])
+                                        .with_tag("munin::master::#{_params[:mastername]}")
+      end
+      _extra_nodes.keys.each do |n|
+        it do
+          expect(exported_resources).to contain_munin__master__node_definition(n)
+                                          .with_address(_extra_nodes[n]['address'])
+                                          .with_mastername(_params[:mastername])
+                                          .with_config(_extra_nodes[n]['config'])
+                                          .with_tag("munin::master::#{_params[:mastername]}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
it seems useful to allow this mechanism natively rather than having module users exporting additional node_definitions manually.  hopefully this also clears up where in Hiera munin::master::node_definitions should be declared.
