### PR TITLE
Automatically enable epel repo on RedHat

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -66,6 +66,7 @@ class munin::master (
   $tls_verify_certificate = $munin::params::master::tls_verify_certificate,
   $host_name              = $munin::params::master::host_name,
   $extra_config           = $munin::params::master::extra_config,
+  $package_install_opt    = $munin::params::master::package_install_opt,
   ) inherits munin::params::master {
 
   if $node_definitions {
@@ -97,10 +98,12 @@ class munin::master (
   }
 
   validate_array($extra_config)
+  validate_array($package_install_opt)
 
   # The munin package and configuration
   package { 'munin':
-    ensure => latest,
+    ensure          => latest,
+    install_options => $package_install_opt
   }
 
   File {

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -48,24 +48,24 @@
 # log files, etc.
 
 class munin::node (
-  $address        = $munin::params::node::address,
-  $allow          = $munin::params::node::allow,
-  $config_root    = $munin::params::node::config_root,
-  $host_name      = $munin::params::node::host_name,
-  $log_dir        = $munin::params::node::log_dir,
-  $usesyslog      = $munin::params::node::usesyslog,
-  $masterconfig   = $munin::params::node::masterconfig,
-  $mastergroup    = $munin::params::node::mastergroup,
-  $mastername     = $munin::params::node::mastername,
-  $nodeconfig     = $munin::params::node::nodeconfig,
-  $package_name   = $munin::params::node::package_name,
-  $plugins        = $munin::params::node::plugins,
-  $service_ensure = $munin::params::node::service_ensure,
-  $service_name   = $munin::params::node::service_name,
-  $export_node    = $munin::params::node::export_node,
-  $file_group     = $munin::params::node::file_group,
+  $address             = $munin::params::node::address,
+  $allow               = $munin::params::node::allow,
+  $config_root         = $munin::params::node::config_root,
+  $host_name           = $munin::params::node::host_name,
+  $log_dir             = $munin::params::node::log_dir,
+  $usesyslog           = $munin::params::node::usesyslog,
+  $masterconfig        = $munin::params::node::masterconfig,
+  $mastergroup         = $munin::params::node::mastergroup,
+  $mastername          = $munin::params::node::mastername,
+  $nodeconfig          = $munin::params::node::nodeconfig,
+  $package_name        = $munin::params::node::package_name,
+  $plugins             = $munin::params::node::plugins,
+  $service_ensure      = $munin::params::node::service_ensure,
+  $service_name        = $munin::params::node::service_name,
+  $export_node         = $munin::params::node::export_node,
+  $file_group          = $munin::params::node::file_group,
+  $package_install_opt = $munin::params::node::package_install_opt,
 ) inherits munin::params::node {
-
   validate_array($allow)
   validate_array($nodeconfig)
   validate_array($masterconfig)
@@ -81,6 +81,7 @@ class munin::node (
   validate_bool($usesyslog)
   validate_absolute_path($log_dir)
   validate_string($file_group)
+  validate_array($package_install_opt)
 
   if $mastergroup {
     $fqn = "${mastergroup};${host_name}"
@@ -98,7 +99,8 @@ class munin::node (
   }
 
   package { $package_name:
-    ensure => installed,
+    ensure          => installed,
+    install_options => $package_install_opt
   }
 
   service { $service_name:

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -15,6 +15,9 @@
 # log_dir: The log directory for the munin node process. Defaults
 # change according to osfamily, see munin::params::node for details.
 #
+# usesyslog : Boolean, specify if you want to log using a syslog (true)
+# or to file (false, it will log to $log_dir)
+#
 # masterconfig: List of configuration lines to append to the munin
 # master node definitinon
 #
@@ -50,6 +53,7 @@ class munin::node (
   $config_root    = $munin::params::node::config_root,
   $host_name      = $munin::params::node::host_name,
   $log_dir        = $munin::params::node::log_dir,
+  $usesyslog      = $munin::params::node::usesyslog,
   $masterconfig   = $munin::params::node::masterconfig,
   $mastergroup    = $munin::params::node::mastergroup,
   $mastername     = $munin::params::node::mastername,
@@ -74,6 +78,7 @@ class munin::node (
   validate_string($service_name)
   validate_re($service_ensure, '^(|running|stopped)$')
   validate_re($export_node, '^(enabled|disabled)$')
+  validate_bool($usesyslog)
   validate_absolute_path($log_dir)
   validate_string($file_group)
 

--- a/manifests/params/master.pp
+++ b/manifests/params/master.pp
@@ -22,8 +22,7 @@ class munin::params::master {
     }
     'RedHat': {
       $config_root = '/etc/munin'
-      $package_install_opt = ['--enablerepo epel']
-
+      $package_install_opt = [{'--enablerepo'=> 'epel'},]
     }
     'Solaris': {
       $config_root = '/opt/local/etc/munin'

--- a/manifests/params/master.pp
+++ b/manifests/params/master.pp
@@ -17,12 +17,17 @@ class munin::params::master {
   $host_name                = $::fqdn
 
   case $::osfamily {
-    'Debian',
+    'Debian': {
+      $package_install_opt = []
+    }
     'RedHat': {
       $config_root = '/etc/munin'
+      $package_install_opt = ['--enablerepo epel']
+
     }
     'Solaris': {
       $config_root = '/opt/local/etc/munin'
+      $package_install_opt = []
     }
     default: {
       fail($message)

--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -14,6 +14,7 @@ class munin::params::node {
   $export_node    = 'enabled'
   $usesyslog      = false
 
+
   case $::osfamily {
     'RedHat': {
       $config_root  = '/etc/munin'
@@ -22,6 +23,7 @@ class munin::params::node {
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/share/munin/plugins'
       $file_group   = 'root'
+      $package_install_opt = ['--enablerepo epel']
     }
     'Debian': {
       $config_root  = '/etc/munin'
@@ -30,6 +32,7 @@ class munin::params::node {
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/share/munin/plugins'
       $file_group   = 'root'
+      $package_install_opt = []
     }
     'Solaris': {
       case $::operatingsystem {
@@ -40,6 +43,7 @@ class munin::params::node {
           $package_name = 'munin-node'
           $plugin_share_dir = '/opt/local/share/munin/plugins'
           $file_group   = 'root'
+          $package_install_opt = []
         }
         default: {
           fail("Unsupported operatingsystem ${::operatingsystem} for osfamily ${::osfamily}")
@@ -53,6 +57,7 @@ class munin::params::node {
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/local/share/munin/plugins'
       $file_group   = 'wheel'
+      $package_install_opt = []
     }
     'OpenBSD': {
       $config_root  = '/etc/munin'
@@ -61,6 +66,7 @@ class munin::params::node {
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/local/libexec/munin/plugins'
       $file_group   = 'wheel'
+      $package_install_opt = []
     }
     default: {
       fail($message)

--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -23,7 +23,7 @@ class munin::params::node {
       $package_name = 'munin-node'
       $plugin_share_dir = '/usr/share/munin/plugins'
       $file_group   = 'root'
-      $package_install_opt = ['--enablerepo epel']
+      $package_install_opt = [{'--enablerepo'=> 'epel'},]
     }
     'Debian': {
       $config_root  = '/etc/munin'

--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -12,6 +12,7 @@ class munin::params::node {
   $plugins        = {}
   $service_ensure = ''
   $export_node    = 'enabled'
+  $usesyslog      = false
 
   case $::osfamily {
     'RedHat': {

--- a/templates/munin.conf.erb
+++ b/templates/munin.conf.erb
@@ -8,8 +8,11 @@ dbdir <%= @dbdir %>
 <% if @htmldir -%>
 htmldir <%= @htmldir %>
 <% end -%>
-<% if @logdir -%>
+<% if @logdir and not @usesyslog -%>
 logdir <%= @logdir %>
+<% end -%>
+<% if @usesyslog -%>
+logfile Sys::Syslog
 <% end -%>
 <% if @rundir -%>
 rundir <%= @rundir %>


### PR DESCRIPTION
This PR adds install_options on the munin-node and munin packages so that, if you are on a RedHat, epel repo wich is disabled by default, the installation will use epel just for this package.