### PR TITLE
Add support for DragonFly BSD and FreeBSD as master

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -65,6 +65,8 @@ class munin::master (
   $tls_private_key        = $munin::params::master::tls_private_key,
   $tls_verify_certificate = $munin::params::master::tls_verify_certificate,
   $host_name              = $munin::params::master::host_name,
+  $file_group             = $munin::params::master::file_group,
+  $munin_server_pkg       = $munin::params::master::munin_server_pkg,
   $extra_config           = $munin::params::master::extra_config,
   ) inherits munin::params::master {
 
@@ -96,18 +98,22 @@ class munin::master (
     }
   }
 
+  validate_string($file_group)
+
+  validate_string($munin_server_pkg)
+
   validate_array($extra_config)
 
   # The munin package and configuration
-  package { 'munin':
+  package { $munin_server_pkg:
     ensure => latest,
   }
 
   File {
     owner   => 'root',
-    group   => 'root',
+    group   => $file_group,
     mode    => '0644',
-    require => Package['munin'],
+    require => Package[$munin_server_pkg],
   }
 
   file { "${config_root}/munin.conf":

--- a/manifests/master/node_definition.pp
+++ b/manifests/master/node_definition.pp
@@ -23,10 +23,17 @@ define munin::master::node_definition (
   $config=[],
 )
 {
+
+  include munin::params::master
+
+  $config_root = $munin::params::master::config_root
+
   validate_string($address)
   validate_array($config)
+  validate_string($config_root)
 
-  $filename=sprintf('/etc/munin/munin-conf.d/node.%s.conf',
+  $filename=sprintf('%s/munin-conf.d/node.%s.conf',
+                    $config_root,
                     regsubst($name, '[^[:alnum:]\.]', '_', 'IG'))
 
   file { $filename:

--- a/manifests/params/master.pp
+++ b/manifests/params/master.pp
@@ -22,13 +22,19 @@ class munin::params::master {
     'Archlinux',
     'Debian',
     'RedHat': {
-      $config_root = '/etc/munin'
+      $config_root      = '/etc/munin'
+      $file_group       = 'root'
+      $munin_server_pkg = 'munin'
     }
     'Solaris': {
-      $config_root = '/opt/local/etc/munin'
+      $config_root      = '/opt/local/etc/munin'
+      $file_group       = 'root'
+      $munin_server_pkg = 'munin'
     }
-    'FreeBSD': {
-      $config_root = '/usr/local/etc/munin'
+    'DragonFly', 'FreeBSD': {
+      $config_root      = '/usr/local/etc/munin'
+      $file_group       = 'wheel'
+      $munin_server_pkg = 'munin-master'
     }
     default: {
       fail($message)

--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -76,5 +76,3 @@ class munin::params::node {
     }
   }
 }
-
-

--- a/templates/munin.conf.erb
+++ b/templates/munin.conf.erb
@@ -34,4 +34,4 @@ tls_verify_certificate = <%= @tls_verify_certificate %>
 <% end -%>
 
 # Where to look for puppet generated munin master configuration.
-includedir /etc/munin/munin-conf.d
+includedir <%= @config_root -%>/munin-conf.d


### PR DESCRIPTION
Although not explicitly stated, in the previous version of this module, support
for FreeBSD and DragonFly BSD was only for the munin node or client. This adds
support for both FreeBSD and DragonFly BSD to act as the munin master or server.

* Package name can vary by OS, so put it in params
* File group on BSDs should be wheel for the root group, so mention that in
  params as well
* Config root on BSDs should be /usr/local, so add that params reference to the
  defined type