### PR TITLE
update rubocop configuration with new cop names, fix complaints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,9 +25,6 @@ Lint/EnsureReturn:
 Lint/HandleExceptions:
   Enabled: true
 
-Lint/LiteralInCondition:
-  Enabled: true
-
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
@@ -43,7 +40,7 @@ Lint/AmbiguousOperator:
 Lint/AssignmentInCondition:
   Enabled: true
 
-Style/SpaceBeforeComment:
+Layout/SpaceBeforeComment:
   Enabled: true
 
 # DISABLED - not useful
@@ -63,6 +60,9 @@ Style/RedundantSelf:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 # DISABLED - not useful
 Style/WhileUntilModifier:
   Enabled: false
@@ -72,7 +72,7 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
 # DISABLED
-Lint/Eval:
+Security/Eval:
   Enabled: false
 
 # DISABLED
@@ -120,22 +120,22 @@ Lint/UselessAssignment:
 Lint/Void:
   Enabled: true
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 Style/Alias:
   Enabled: false
 
-Style/AlignArray:
+Layout/AlignArray:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: false
 
 Metrics/BlockNesting:
@@ -153,13 +153,10 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Enabled: false
 
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Enabled: false
 
 Style/CharacterLiteral:
-  Enabled: false
-
-Style/ClassAndModuleCamelCase:
   Enabled: false
 
 Style/ClassAndModuleChildren:
@@ -187,67 +184,49 @@ Style/WordArray:
 Style/UnneededPercentQ:
   Enabled: false
 
-Style/Tab:
+Layout/Tab:
   Enabled: false
 
-Style/SpaceBeforeSemicolon:
+Layout/SpaceInsideBlockBraces:
   Enabled: false
 
-Style/TrailingBlankLines:
+Layout/SpaceInsideBrackets:
   Enabled: false
 
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideParens:
   Enabled: false
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/LeadingCommentSpace:
   Enabled: false
 
-Style/SpaceInsideParens:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
-Style/LeadingCommentSpace:
+Layout/SpaceAroundKeyword:
   Enabled: false
 
-Style/SingleSpaceBeforeFirstArg:
+Layout/SpaceAfterMethodName:
   Enabled: false
 
-Style/SpaceAfterColon:
+Layout/SpaceAfterSemicolon:
   Enabled: false
 
-Style/SpaceAfterComma:
+Layout/SpaceAroundOperators:
   Enabled: false
 
-Style/SpaceAfterControlKeyword:
+Layout/SpaceBeforeBlockBraces:
   Enabled: false
 
-Style/SpaceAfterMethodName:
-  Enabled: false
-
-Style/SpaceAfterNot:
-  Enabled: false
-
-Style/SpaceAfterSemicolon:
-  Enabled: false
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: false
-
-Style/SpaceAroundOperators:
-  Enabled: false
-
-Style/SpaceBeforeBlockBraces:
-  Enabled: false
-
-Style/SpaceBeforeComma:
+Layout/SpaceBeforeComma:
   Enabled: false
 
 Style/CollectionMethods:
   Enabled: false
 
-Style/CommentIndentation:
+Layout/CommentIndentation:
   Enabled: false
 
 Style/ColonMethodCall:
@@ -259,7 +238,7 @@ Style/CommentAnnotation:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Style/ConstantName:
+Naming/ConstantName:
   Enabled: false
 
 Style/Documentation:
@@ -268,10 +247,10 @@ Style/Documentation:
 Style/DefWithParentheses:
   Enabled: false
 
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: false
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # DISABLED - used for converting to bool
@@ -281,28 +260,28 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Enabled: false
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   Enabled: false
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: false
 
-Style/EmptyLines:
+Layout/EmptyLines:
   Enabled: false
 
-Style/EmptyLinesAroundAccessModifier:
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
 Style/EmptyLiteral:
@@ -311,7 +290,7 @@ Style/EmptyLiteral:
 Metrics/LineLength:
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 
 Style/MethodDefParentheses:
@@ -320,13 +299,13 @@ Style/MethodDefParentheses:
 Style/LineEndConcatenation:
   Enabled: false
 
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Enabled: false
 
 Style/StringLiterals:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
 
 Style/GlobalVars:
@@ -341,7 +320,7 @@ Style/IfUnlessModifier:
 Style/MultilineIfThen:
   Enabled: false
 
-Style/MultilineOperationIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: false
 
 Style/NegatedIf:
@@ -371,7 +350,7 @@ Style/UnlessElse:
 Style/VariableInterpolation:
   Enabled: false
 
-Style/VariableName:
+Naming/VariableName:
   Enabled: false
 
 Style/WhileUntilDo:
@@ -380,7 +359,7 @@ Style/WhileUntilDo:
 Style/EvenOdd:
   Enabled: false
 
-Style/FileName:
+Naming/FileName:
   Enabled: false
 
 Style/For:
@@ -389,13 +368,10 @@ Style/For:
 Style/Lambda:
   Enabled: false
 
-Style/MethodName:
+Naming/MethodName:
   Enabled: false
 
 Style/MultilineTernaryOperator:
-  Enabled: false
-
-Style/NestedTernaryOperator:
   Enabled: false
 
 Style/NilComparison:
@@ -405,6 +381,9 @@ Style/FormatString:
   Enabled: false
 
 Style/MultilineBlockChain:
+  Enabled: false
+
+Layout/MultilineHashBraceLayout:
   Enabled: false
 
 Style/Semicolon:
@@ -425,9 +404,6 @@ Style/NumericLiterals:
 Style/OneLineConditional:
   Enabled: false
 
-Style/OpMethod:
-  Enabled: false
-
 Style/ParenthesesAroundCondition:
   Enabled: false
 
@@ -437,7 +413,7 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   Enabled: false
 
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 Style/RedundantException:
@@ -470,7 +446,7 @@ Metrics/ParameterLists:
 Lint/RequireParentheses:
   Enabled: false
 
-Lint/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/ModuleFunction:

--- a/Gemfile
+++ b/Gemfile
@@ -1,33 +1,32 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rake"
-  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
-  gem "rspec", '< 3.2.0'
-  gem "rspec-puppet"
-  gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
-  gem "rspec-puppet-facts"
-  gem 'rubocop', '0.33.0'
-  gem 'simplecov', '>= 0.11.0'
-  gem 'simplecov-console'
-
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
   gem "puppet-lint-absolute_classname-check"
+  gem "puppet-lint-classes_and_types_beginning_with_digits-check"
   gem "puppet-lint-leading_zero-check"
   gem "puppet-lint-trailing_comma-check"
-  gem "puppet-lint-version_comparison-check"
-  gem "puppet-lint-classes_and_types_beginning_with_digits-check"
   gem "puppet-lint-unquoted_string-check"
+  gem "puppet-lint-version_comparison-check"
+  gem "puppetlabs_spec_helper"
+  gem "rake"
+  gem "rspec", '~> 3.0' # works with '~> 3.6.0'
+  gem "rspec-puppet"
+  gem "rspec-puppet-facts"
+  gem 'rubocop' # works with '0.51.0'
+  gem 'simplecov', '>= 0.11.0'
+  gem 'simplecov-console'
 end
 
 group :development do
+  gem "guard-rake"
   gem "travis"
   gem "travis-lint"
-  gem "guard-rake"
 end
 
 group :system_tests do
   gem "beaker"
-  gem "beaker-rspec"
   gem "beaker-puppet_install_helper"
+  gem "beaker-rspec"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -53,10 +53,10 @@ task :contributors do
 end
 
 desc "Run syntax, lint, and spec tests."
-task :test => [
-  :metadata_lint,
-  :syntax,
-  :lint,
-  :rubocop,
-  :spec,
+task :test => %i[
+  metadata_lint
+  syntax
+  lint
+  rubocop
+  spec
 ]

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -4,10 +4,10 @@ describe 'munin and munin-node' do
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'should work idempotently with no errors' do
-      pp = <<-EOS
+      pp = <<-PUPPET_CODE
       class { 'munin::master': }
       class { 'munin::node': }
-      EOS
+      PUPPET_CODE
 
       # Run it twice and test for idempotency
       apply_manifest(pp, :catch_failures => true)

--- a/spec/acceptance/munin__master_spec.rb
+++ b/spec/acceptance/munin__master_spec.rb
@@ -4,9 +4,9 @@ describe 'munin::master class' do
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'should work idempotently with no errors' do
-      pp = <<-EOS
+      pp = <<-PUPPET_CODE
       class { 'munin::master': }
-      EOS
+      PUPPET_CODE
 
       # Run it twice and test for idempotency
       apply_manifest(pp, :catch_failures => true)

--- a/spec/acceptance/munin__node_spec.rb
+++ b/spec/acceptance/munin__node_spec.rb
@@ -4,9 +4,9 @@ describe 'munin::node class' do
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'should work idempotently with no errors' do
-      pp = <<-EOS
+      pp = <<-PUPPET_CODE
         class { 'munin::node': }
-      EOS
+      PUPPET_CODE
 
       # Run it twice and test for idempotency
       apply_manifest(pp, :catch_failures => true)

--- a/spec/classes/munin_master_spec.rb
+++ b/spec/classes/munin_master_spec.rb
@@ -10,11 +10,11 @@ describe 'munin::master' do
   on_supported_os.each do |os, facts|
 
     # Avoid testing on distributions similar to RedHat and Debian
-    next if /^(ubuntu|centos|scientific|oraclelinux)-/.match(os)
+    next if os =~ /^(ubuntu|centos|scientific|oraclelinux)-/
 
     # No need to test all os versions as long as os version is not
     # used in the params class
-    next if /^(debian-[67]|redhat-[56]|freebsd-9)-/.match(os)
+    next if os =~ /^(debian-[67]|redhat-[56]|freebsd-9)-/
 
     context "on #{os}" do
       let(:facts) do
@@ -165,7 +165,7 @@ describe 'munin::master' do
         end
       end
 
-      %w( enabled disabled mine unclaimed invalid ).each do |param|
+      %w(enabled disabled mine unclaimed invalid).each do |param|
         context "with collect_nodes => #{param}" do
           let(:params) do
             { :collect_nodes => param }
@@ -178,7 +178,7 @@ describe 'munin::master' do
         end
       end
 
-    end # on os
+    end
   end
 
 end

--- a/spec/classes/munin_node_export_spec.rb
+++ b/spec/classes/munin_node_export_spec.rb
@@ -22,12 +22,10 @@ describe 'munin::node::export' do
   on_supported_os.each do |os, facts|
 
     context "on #{os}" do
-      let(:facts) do facts end
-      let(:params) do _params end
+      let(:facts) { facts }
+      let(:params) { _params }
 
-      it do
-        should compile.with_all_deps
-      end
+      it { should compile.with_all_deps }
 
       it do
         expect(exported_resources).to have_munin__master__node_definition_resource_count(1)
@@ -41,8 +39,8 @@ describe 'munin::node::export' do
     end
 
     context "on #{os} with extra nodes" do
-      let(:facts) do facts end
-      let(:params) do _params.merge({ :node_definitions => _extra_nodes }) end
+      let(:facts) { facts }
+      let(:params) { _params.merge({ :node_definitions => _extra_nodes }) }
 
       it { should compile.with_all_deps }
 
@@ -55,7 +53,7 @@ describe 'munin::node::export' do
                                         .with_mastername(_params[:mastername])
                                         .with_tag("munin::master::#{_params[:mastername]}")
       end
-      _extra_nodes.keys.each do |n|
+      _extra_nodes.each_key do |n|
         it do
           expect(exported_resources).to contain_munin__master__node_definition(n)
                                           .with_address(_extra_nodes[n]['address'])

--- a/spec/classes/munin_node_spec.rb
+++ b/spec/classes/munin_node_spec.rb
@@ -11,16 +11,14 @@ describe 'munin::node' do
   on_supported_os.each do |os, facts|
 
     # Avoid testing on distributions similar to RedHat and Debian
-    next if /^(ubuntu|centos|scientific|oraclelinux)-/.match(os)
+    next if os =~ /^(ubuntu|centos|scientific|oraclelinux)-/
 
     # No need to test all os versions as long as os version is not
     # used in the params class
-    next if /^(debian-[67]|redhat-[56]|freebsd-9)-/.match(os)
+    next if os =~ /^(debian-[67]|redhat-[56]|freebsd-9)-/
 
     context "on #{os}" do
-      let(:facts) do
-        facts
-      end
+      let(:facts) { facts }
 
       it { should compile.with_all_deps }
 
@@ -32,21 +30,18 @@ describe 'munin::node' do
       munin_plugin_dir = "#{munin_confdir}/plugins"
       munin_plugin_conf_dir = "#{munin_confdir}/plugin-conf.d"
 
-      case facts[:osfamily]
-      when 'Solaris'
-        munin_node_service = 'smf:/munin-node'
-      else
-        munin_node_service = 'munin-node'
-      end
+      munin_node_service =
+        case facts[:osfamily]
+        when 'Solaris' then 'smf:/munin-node'
+        else 'munin-node'
+        end
 
-      case facts[:osfamily]
-      when 'Solaris'
-        log_dir = '/var/opt/log/munin'
-      when 'RedHat'
-        log_dir = '/var/log/munin-node'
-      else
-        log_dir = '/var/log/munin'
-      end
+      log_dir =
+        case facts[:osfamily]
+        when 'Solaris' then '/var/opt/log/munin'
+        when 'RedHat' then '/var/log/munin-node'
+        else '/var/log/munin'
+        end
 
       it { should contain_service(munin_node_service) }
       it { should contain_file(munin_node_conf) }

--- a/spec/defines/munin_plugin_spec.rb
+++ b/spec/defines/munin_plugin_spec.rb
@@ -17,11 +17,11 @@ describe 'munin::plugin', :type => 'define' do
   on_supported_os.each do |os, facts|
 
     # Avoid testing on distributions similar to RedHat and Debian
-    next if /^(ubuntu|centos|scientific|oraclelinux)-/.match(os)
+    next if os =~ /^(ubuntu|centos|scientific|oraclelinux)-/
 
     # No need to test all os versions as long as os version is not
     # used in the params class
-    next if /^(debian-[67]|redhat-[56]|freebsd-9)-/.match(os)
+    next if os =~ /^(debian-[67]|redhat-[56]|freebsd-9)-/
 
     context "on #{os}" do
       let(:facts) do

--- a/spec/defines/regression_13_munin_plugin_config_name_spec.rb
+++ b/spec/defines/regression_13_munin_plugin_config_name_spec.rb
@@ -11,16 +11,14 @@ describe 'munin::plugin' do
   on_supported_os.each do |os, facts|
 
     # Avoid testing on distributions similar to RedHat and Debian
-    next if /^(ubuntu|centos|scientific|oraclelinux)-/.match(os)
+    next if os =~ /^(ubuntu|centos|scientific|oraclelinux)-/
 
     # No need to test all os versions as long as os version is not
     # used in the params class
-    next if /^(debian-[67]|redhat-[56]|freebsd-9)-/.match(os)
+    next if os =~ /^(debian-[67]|redhat-[56]|freebsd-9)-/
 
     context "on #{os}" do
-      let(:facts) do
-        facts
-      end
+      let(:facts) { facts }
 
       conf_dir = _conf_dir[facts[:osfamily]]
 
@@ -37,16 +35,15 @@ describe 'munin::plugin' do
 
       context 'with config_label set, label should be set to config_label' do
         let(:params) do
-          { config: ['env.foo bar'],
-            config_label: 'foo_' }
+          { config: ['env.foo bar'], config_label: 'foo_' }
         end
         it do
           should contain_file("#{conf_dir}/plugin-conf.d/testplugin.conf")
                   .with_content(/^\[foo_\]$/)
         end
       end
+    end
 
-    end # on os
   end
 
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -16,7 +16,7 @@ RSpec.configure do |c|
     # Install module and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'munin')
     hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0, 1] }
     end
   end
 end


### PR DESCRIPTION
the rubocop which was hardcoded in Gemfile was incompatible with other newer gems, so I let the versioning loose and fixed up the .rubocop.yml + fixed up a little code.

notice that the %i[] syntax introduced in Rakefile breaks Ruby 1.9 support, but I think Ruby 2.x was required already.
