### PR TITLE
using undef is fickle.  make mastername either false or a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ Parameters for exporting a munin node definition
   master node definitinon
 
 * **mastername**: The name of the munin master server which will
-  collect the node definition.
+  collect the node definition.  By default this is set to `false`,
+  which means this node will be collected by a master with
+  `collect_nodes` mode "unclaimed", or the (default) "enabled" mode
+  which will collect every node regardless of this setting.
 
 * **mastergroup**: The group used on the master to construct a FQN for
   this node. Defaults to "", which in turn makes munin master use the

--- a/manifests/master/node_definition.pp
+++ b/manifests/master/node_definition.pp
@@ -12,14 +12,14 @@
 #   or a ssh:// uri for munin-async node. Required.
 #
 # - mastername: The name of the munin master server which will collect
-#   the node definition.
+#   the node definition.  Ignored, present for backwards compatibility.
 #
 # - config: An array of configuration lines to be added to the node
 #   definition. Default is an empty array.
 #
 define munin::master::node_definition (
   $address,
-  $mastername='',
+  $mastername=false,
   $config=[],
 )
 {

--- a/manifests/node/export.pp
+++ b/manifests/node/export.pp
@@ -11,9 +11,14 @@ class munin::node::export (
   $node_definitions = {},
 )
 {
+  if $mastername {
+    $_tag = "munin::master::${mastername}"
+  } else {
+    $_tag = 'munin::master::'
+  }
   Munin::Master::Node_definition {
     mastername => $mastername,
-    tag        => "munin::master::${mastername}",
+    tag        => $_tag,
   }
   @@munin::master::node_definition{ $fqn:
     address => $address,

--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -11,7 +11,7 @@ class munin::params::node {
   $allow          = []
   $masterconfig   = []
   $mastergroup    = undef
-  $mastername     = undef
+  $mastername     = false
   $nodeconfig     = []
   $plugins        = {}
   $service_ensure = undef


### PR DESCRIPTION
Special case tag for unset (false) mastername for backwards compatibility - the undef value becomes "" in string context.  If anyone has set it to "" in Hiera to disable this, that will continue to work, too.

The reason for this patch is my rspec tests for Puppet environments failing with "Unknown variable: 'mastername'".  This might be an rspec bug, but passing an undef value to a define is semantically equivalent to not passing the variable at all.  IMHO it is better to be explicit about this.
