### PR TITLE
fix paths for Archlinux

### DIFF
--- a/manifests/params/node.pp
+++ b/manifests/params/node.pp
@@ -23,7 +23,14 @@ class munin::params::node {
   $timeout         = undef
 
   case $::osfamily {
-    'Archlinux',
+    'Archlinux':  {
+      $config_root  = '/etc/munin'
+      $log_dir      = '/var/log/munin'
+      $service_name = 'munin-node'
+      $package_name = 'munin-node'
+      $plugin_share_dir = '/usr/lib/munin/plugins'
+      $file_group   = 'root'
+    }
     'RedHat': {
       $config_root  = '/etc/munin'
       $log_dir      = '/var/log/munin-node'

--- a/spec/defines/munin_plugin_spec.rb
+++ b/spec/defines/munin_plugin_spec.rb
@@ -9,6 +9,7 @@ t_share_dir = {}
 t_share_dir.default = '/usr/share/munin'
 t_share_dir['Solaris'] = '/opt/local/share/munin'
 t_share_dir['FreeBSD'] = '/usr/local/share/munin'
+t_share_dir['Archlinux'] = '/usr/lib/munin'
 
 describe 'munin::plugin', type: 'define' do
   let(:title) { 'testplugin' }


### PR DESCRIPTION
noticed inconsistency in testing values, example failed at
./spec/classes/munin_node_spec.rb:54

  on archlinux-4-x86_64
    with no parameters

used package contents from
  https://www.archlinux.org/packages/extra/any/munin-node/
to find hopefully correct values.