### PR TITLE
fixing setting tag on exported resource node_definition

### DIFF
--- a/manifests/node/export.pp
+++ b/manifests/node/export.pp
@@ -13,11 +13,11 @@ class munin::node::export (
 {
   Munin::Master::Node_definition {
     mastername => $mastername,
-    tag        => "munin::master::${mastername}",
   }
   @@munin::master::node_definition{ $fqn:
     address => $address,
     config  => $masterconfig,
+    tag     => "munin::master::${mastername}",
   }
   if ! empty($node_definitions) {
     create_resources('@@munin::master::node_definition', $node_definitions)


### PR DESCRIPTION
when using "collect_nodes: mine" on master no node_definition resource gets collected because they do not get exported with the tag set. (only as parameter, not under "tags")

this PR fixes that.