### PR TITLE
Fix #63 - Replace validate functions with data types

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -78,58 +78,30 @@
 # @param extra_config [Array] Extra lines of config to put in
 #   munin.conf.
 class munin::master (
-  $node_definitions       = $munin::params::master::node_definitions,
-  $graph_strategy         = $munin::params::master::graph_strategy,
-  $html_strategy          = $munin::params::master::html_strategy,
-  $config_root            = $munin::params::master::config_root,
-  $collect_nodes          = $munin::params::master::collect_nodes,
-  $dbdir                  = $munin::params::master::dbdir,
-  $htmldir                = $munin::params::master::htmldir,
-  $logdir                 = $munin::params::master::logdir,
-  $rundir                 = $munin::params::master::rundir,
-  $tls                    = $munin::params::master::tls,
-  $tls_certificate        = $munin::params::master::tls_certificate,
-  $tls_private_key        = $munin::params::master::tls_private_key,
-  $tls_verify_certificate = $munin::params::master::tls_verify_certificate,
-  $host_name              = $munin::params::master::host_name,
-  $file_group             = $munin::params::master::file_group,
-  $package_name           = $munin::params::master::package_name,
-  $extra_config           = $munin::params::master::extra_config,
+  Hash $node_definitions                                       = $munin::params::master::node_definitions,
+  Enum['cgi','cron'] $graph_strategy                           = $munin::params::master::graph_strategy,
+  Enum['cgi','cron'] $html_strategy                            = $munin::params::master::html_strategy,
+  Stdlib::Absolutepath $config_root                            = $munin::params::master::config_root,
+  Enum['enabled','disabled','mine','unclaimed'] $collect_nodes = $munin::params::master::collect_nodes,
+  Optional[Stdlib::Absolutepath] $dbdir                        = $munin::params::master::dbdir,
+  Optional[Stdlib::Absolutepath] $htmldir                      = $munin::params::master::htmldir,
+  Optional[Stdlib::Absolutepath] $logdir                       = $munin::params::master::logdir,
+  Optional[Stdlib::Absolutepath] $rundir                       = $munin::params::master::rundir,
+  Enum['enabled','disabled'] $tls                              = $munin::params::master::tls,
+  Optional[Stdlib::Absolutepath] $tls_certificate              = $munin::params::master::tls_certificate,
+  Optional[Stdlib::Absolutepath] $tls_private_key              = $munin::params::master::tls_private_key,
+  Enum['yes','no'] $tls_verify_certificate                     = $munin::params::master::tls_verify_certificate,
+  String $host_name                                            = $munin::params::master::host_name,
+  String $file_group                                           = $munin::params::master::file_group,
+  String $package_name                                         = $munin::params::master::package_name,
+  Array $extra_config                                          = $munin::params::master::extra_config,
   ) inherits munin::params::master {
 
-  if $node_definitions {
-    validate_hash($node_definitions)
-  }
-  if $graph_strategy {
-    validate_re($graph_strategy, [ '^cgi$', '^cron$' ])
-  }
-  if $html_strategy {
-    validate_re($html_strategy, [ '^cgi$', '^cron$' ])
-  }
-  validate_re($collect_nodes, [ '^enabled$', '^disabled$', '^mine$',
-                                '^unclaimed$' ])
-  validate_absolute_path($config_root)
-
-  validate_re($tls, [ '^enabled$', '^disabled$' ])
-
-  if $tls == 'enabled' {
-    validate_re($tls_verify_certificate, [ '^yes$', '^no$' ])
-    validate_absolute_path($tls_private_key)
-    validate_absolute_path($tls_certificate)
-  }
-
   if $host_name {
-    validate_string($host_name)
     if ! is_domain_name($host_name) {
       fail('host_name should be a valid domain name')
     }
   }
-
-  validate_string($file_group)
-
-  validate_string($package_name)
-
-  validate_array($extra_config)
 
   # The munin package and configuration
   package { $package_name:
@@ -162,7 +134,5 @@ class munin::master (
   }
 
   # Create static node definitions
-  if $node_definitions {
-    create_resources(munin::master::node_definition, $node_definitions, {})
-  }
+  create_resources(munin::master::node_definition, $node_definitions, {})
 }

--- a/manifests/master/collect.pp
+++ b/manifests/master/collect.pp
@@ -10,8 +10,8 @@
 # @param host_name [String] Host named used for selecting exported
 #   resources to collect.
 class munin::master::collect (
-  $collect_nodes,
-  $host_name,
+  Enum['enabled','disabled','mine','unclaimed'] $collect_nodes,
+  String $host_name,
 )
 {
   case $collect_nodes {

--- a/manifests/master/node_definition.pp
+++ b/manifests/master/node_definition.pp
@@ -16,9 +16,9 @@
 #   added to the node definition.
 #
 define munin::master::node_definition (
-  $address,
-  $mastername='',
-  $config=[],
+  String $address,
+  Optional[String] $mastername = '',
+  Array[String] $config = [],
 )
 {
 
@@ -26,11 +26,7 @@ define munin::master::node_definition (
 
   $config_root = $munin::params::master::config_root
 
-  validate_string($address)
-  validate_array($config)
-  validate_string($config_root)
-
-  $filename=sprintf('%s/munin-conf.d/node.%s.conf',
+  $filename = sprintf('%s/munin-conf.d/node.%s.conf',
                     $config_root,
                     regsubst($name, '[^[:alnum:]\.]', '_', 'IG'))
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -83,61 +83,37 @@
 #   runtime timeout for this node. Defaults to undef, which lets
 #   munin-node use its default of 10 seconds.
 class munin::node (
-  $address         = $munin::params::node::address,
-  $allow           = $munin::params::node::allow,
-  $bind_address    = $munin::params::node::bind_address,
-  $bind_port       = $munin::params::node::bind_port,
-  $config_root     = $munin::params::node::config_root,
-  $host_name       = $munin::params::node::host_name,
-  $log_dir         = $munin::params::node::log_dir,
-  $log_file        = $munin::params::node::log_file,
-  $masterconfig    = $munin::params::node::masterconfig,
-  $mastergroup     = $munin::params::node::mastergroup,
-  $mastername      = $munin::params::node::mastername,
-  $nodeconfig      = $munin::params::node::nodeconfig,
-  $package_name    = $munin::params::node::package_name,
-  $plugins         = $munin::params::node::plugins,
-  $purge_configs   = $munin::params::node::purge_configs,
-  $service_ensure  = $munin::params::node::service_ensure,
-  $service_name    = $munin::params::node::service_name,
-  $export_node     = $munin::params::node::export_node,
-  $file_group      = $munin::params::node::file_group,
-  $log_destination = $munin::params::node::log_destination,
-  $syslog_facility = $munin::params::node::syslog_facility,
-  $timeout         = $munin::params::node::timeout,
+  String $address                                     = $munin::params::node::address,
+  Array $allow                                        = $munin::params::node::allow,
+  String $bind_address                                = $munin::params::node::bind_address,
+  Variant[Integer,String] $bind_port                  = $munin::params::node::bind_port,
+  Stdlib::Absolutepath $config_root                   = $munin::params::node::config_root,
+  String $host_name                                   = $munin::params::node::host_name,
+  Stdlib::Absolutepath $log_dir                       = $munin::params::node::log_dir,
+  String $log_file                                    = $munin::params::node::log_file,
+  Array $masterconfig                                 = $munin::params::node::masterconfig,
+  Optional[String] $mastergroup                       = $munin::params::node::mastergroup,
+  Optional[String] $mastername                        = $munin::params::node::mastername,
+  Array $nodeconfig                                   = $munin::params::node::nodeconfig,
+  String $package_name                                = $munin::params::node::package_name,
+  Hash $plugins                                       = $munin::params::node::plugins,
+  Boolean $purge_configs                              = $munin::params::node::purge_configs,
+  Optional[Enum['running','stopped']] $service_ensure = $munin::params::node::service_ensure,
+  String $service_name                                = $munin::params::node::service_name,
+  Enum['enabled','disabled'] $export_node             = $munin::params::node::export_node,
+  String $file_group                                  = $munin::params::node::file_group,
+  Enum['file','syslog'] $log_destination              = $munin::params::node::log_destination,
+  Optional[Pattern[/^(?:\d+|(?:kern|user|mail|daemon|auth|syslog|lpr|news|uucp|authpriv|ftp|cron|local[0-7]))$/]] $syslog_facility = $munin::params::node::syslog_facility,
+  Optional[Integer] $timeout                          = $munin::params::node::timeout,
 ) inherits munin::params::node {
-
-  validate_array($allow)
-  validate_array($nodeconfig)
-  validate_array($masterconfig)
-  if $mastergroup { validate_string($mastergroup) }
-  if $mastername { validate_string($mastername) }
-  validate_hash($plugins)
-  validate_string($address)
-  validate_absolute_path($config_root)
-  validate_string($package_name)
-  validate_string($service_name)
-  if $service_ensure { validate_re($service_ensure, '^(running|stopped)$') }
-  validate_re($export_node, '^(enabled|disabled)$')
-  validate_absolute_path($log_dir)
-  validate_re($log_destination, '^(?:file|syslog)$')
-  validate_string($log_file)
-  validate_string($file_group)
-  validate_bool($purge_configs)
-  if $timeout { validate_integer($timeout) }
 
   case $log_destination {
     'file': {
       $_log_file = "${log_dir}/${log_file}"
-      validate_absolute_path($_log_file)
+      assert_type(Stdlib::Absolutepath, $_log_file)
     }
     'syslog': {
       $_log_file = 'Sys::Syslog'
-      if $syslog_facility {
-        validate_string($syslog_facility)
-        validate_re($syslog_facility,
-                    '^(?:\d+|(?:kern|user|mail|daemon|auth|syslog|lpr|news|uucp|authpriv|ftp|cron|local[0-7]))$')
-      }
     }
     default: {
       fail('log_destination is not set')

--- a/manifests/node/export.pp
+++ b/manifests/node/export.pp
@@ -22,11 +22,11 @@
 # @param node_definitions [Hash] A hash of extra
 #   Munin::Master::Node_definitions to export from this node
 class munin::node::export (
-  $address,
-  $fqn,
-  $masterconfig,
-  $mastername,
-  $node_definitions = {},
+  String $address,
+  String $fqn,
+  Array[String] $masterconfig,
+  Optional[String] $mastername,
+  Hash $node_definitions = {},
 )
 {
   Munin::Master::Node_definition {
@@ -37,7 +37,5 @@ class munin::node::export (
     address => $address,
     config  => $masterconfig,
   }
-  if ! empty($node_definitions) {
-    create_resources('@@munin::master::node_definition', $node_definitions)
-  }
+  create_resources('@@munin::master::node_definition', $node_definitions)
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -43,25 +43,21 @@
 #
 # @param config_label [String] Label for munin plugin config
 define munin::plugin (
-    $ensure='',
-    $source=undef,
-    $target='',
-    $config=undef,
-    $config_label=undef,
+    Enum['present','absent','link',''] $ensure = '',
+    Optional[String] $source                   = undef,
+    String $target                             = '',
+    Optional[Array[String]] $config            = undef,
+    Optional[String] $config_label             = undef,
 )
 {
 
     include ::munin::node
-
-    $plugin_share_dir=$munin::node::plugin_share_dir
-    validate_absolute_path($plugin_share_dir)
 
     File {
         require => Package[$munin::node::package_name],
         notify  => Service[$munin::node::service_name],
     }
 
-    validate_re($ensure, '^(|link|present|absent)$')
     case $ensure {
         'present', 'absent': {
             $handle_plugin = true
@@ -82,7 +78,7 @@ define munin::plugin (
                     $plugin_target = "${munin::node::plugin_share_dir}/${target}"
                 }
             }
-            validate_absolute_path($plugin_target)
+            assert_type(Stdlib::Absolutepath, $plugin_target)
         }
         default: {
             $handle_plugin = false
@@ -112,7 +108,7 @@ define munin::plugin (
 
     # Config
 
-    file{ "${munin::node::config_root}/plugin-conf.d/${name}.conf":
+    file { "${munin::node::config_root}/plugin-conf.d/${name}.conf":
       ensure  => $config_ensure,
       content => template('munin/plugin_conf.erb'),
     }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.0 < 6.0.0"
+      "version_requirement": ">= 4.13.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/munin_master_spec.rb
+++ b/spec/classes/munin_master_spec.rb
@@ -161,7 +161,7 @@ describe 'munin::master' do
           { extra_config: token }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{is not an Array}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError, %r{got String}) }
       end
 
       ['test.example.com', 'invalid/hostname.example.com'].each do |param|
@@ -185,7 +185,7 @@ describe 'munin::master' do
           end
 
           if param == 'invalid'
-            it { is_expected.to raise_error(Puppet::Error, %r{validate_re}) }
+            it { is_expected.to raise_error(Puppet::PreformattedError, %r{got 'invalid'}) }
           else
             it { is_expected.to compile.with_all_deps }
           end

--- a/spec/classes/munin_node_spec.rb
+++ b/spec/classes/munin_node_spec.rb
@@ -134,7 +134,7 @@ describe 'munin::node' do
               syslog_facility: 'wrong' }
           end
 
-          it { expect { is_expected.to compile.with_all_deps }.to raise_error(%r{validate_re}) }
+          it { expect { is_expected.to compile.with_all_deps }.to raise_error(%r{got 'wrong'}) }
         end
       end
 


### PR DESCRIPTION
This pull request replaces log deprecated validate functions and uses the proper data types which are supported since puppet 4.