### PR TITLE
Fixed broken munin tls config

### DIFF
--- a/templates/munin.conf.erb
+++ b/templates/munin.conf.erb
@@ -21,10 +21,10 @@ html_strategy  <%= @html_strategy %>
 graph_strategy <%= @graph_strategy %>
 <% end -%>
 <% if @tls == 'enabled' -%>
-tls = <%= @tls %>
-tls_certificate = <%= @tls_certificate %>
-tls_private_key = <%= @tls_private_key %>
-tls_verify_certificate = <%= @tls_verify_certificate %>
+tls <%= @tls %>
+tls_certificate <%= @tls_certificate %>
+tls_private_key <%= @tls_private_key %>
+tls_verify_certificate <%= @tls_verify_certificate %>
 <% end -%>
 <% if @extra_config -%>
 


### PR DESCRIPTION
Munin settings are not assigned by "=" but only with: <key> <value>