### PR TITLE
Support master on OpenBSD

### DIFF
--- a/data/osfamily/OpenBSD.yaml
+++ b/data/osfamily/OpenBSD.yaml
@@ -1,4 +1,8 @@
 ---
+munin::master::config_root: '/etc/munin'
+munin::master::file_group: 'wheel'
+munin::master::package_name: 'munin-server'
+
 munin::node::config_root: "/etc/munin"
 munin::node::log_dir: "/var/log/munin"
 munin::node::service_name: "munin_node"

--- a/spec/classes/munin_master_spec.rb
+++ b/spec/classes/munin_master_spec.rb
@@ -8,6 +8,7 @@ t_conf_dir['FreeBSD'] = '/usr/local/etc/munin'
 t_package = {}
 t_package.default = 'munin'
 t_package['FreeBSD'] = 'munin-master'
+t_package['OpenBSD'] = 'munin-server'
 
 describe 'munin::master' do
   on_supported_os.each do |os, facts|


### PR DESCRIPTION
Contrary to other BSDs, there is no separate `/usr/local/etc/` and the
package is called `munin-server` rather than `munin-master` like
anywhere else.
