### PR TITLE
load munin::node::plugin_share_dir via automatic lookup

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -146,6 +146,7 @@ class munin::node (
   Array                           $nodeconfig,
   String                          $package_name,
   Hash                            $plugins,
+  Stdlib::Absolutepath            $plugin_share_dir,
   Boolean                         $purge_configs,
   Enum['running','stopped']       $service_ensure,
   String                          $service_name,

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -97,10 +97,10 @@ define munin::plugin (
 ) {
   include munin::node
 
-  $plugin_share_dir = lookup('munin::node::plugin_share_dir', Stdlib::Absolutepath)
-  $node_config_root = lookup('munin::node::config_root', Stdlib::Absolutepath)
-  $node_package_name = lookup('munin::node::package_name', String)
-  $node_service_name = lookup('munin::node::service_name', String)
+  $plugin_share_dir = $munin::node::plugin_share_dir
+  $node_config_root = $munin::node::config_root
+  $node_package_name = $munin::node::package_name
+  $node_service_name = $munin::node::service_name
 
   File {
     require => Package[$node_package_name],


### PR DESCRIPTION
when `munin::plugin` uses `lookup()` directly, this effectively means the variable value is unavailable to auxilliary classes which need to install additional files in the plugin directory.

the patch removes the other occurences of `lookup()` too, since they only complicate the code, and potentially cause an inconsistency if the user passes value into `munin::node` via explicit parameters rather than via Hiera.